### PR TITLE
adding template to match release names with existing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
           CR_CHARTS_REPO: https://fusionauth.github.io/charts
           CR_INDEX_PATH: index.yaml
           CR_PAGES_BRANCH: master
+          CR_RELEASE_NAME_TEMPLATE: "{{ .Version }}"
         run: |
           cr package chart
           cr upload


### PR DESCRIPTION
<!--  Thank you for contributing to the fusionauth/charts repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: 
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Forces the `chart-releaser` util to name releases the same as the tag pushed that triggers the release.

