### PR TITLE
Fix #69 and provide correct ingress api version for newer k8s versions

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -28,7 +28,9 @@ If release name contains chart name it will be used as a full name.
 Set apiVersion for ingress
 */}}
 {{- define "fusionauth.ingressApiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 networking.k8s.io/v1beta1
 {{- else -}}
 extensions/v1beta1

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -28,17 +28,27 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    - host: {{ or .host . | quote }}
       http:
         paths:
         {{- if $extraPaths }}
 {{ $extraPaths | toYaml | indent 10 }}
         {{- end }}
         {{- range $ingressPaths }}
-          - path: {{ . }}
+          - path: {{ or .path . }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
+              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Closes #69 .

Check for new igress api version and implement those definitions. The fallbacks into old versions are preserved and all changes are derived from the example provided by `helm create …` and the [official api documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#servicebackendport-v1-networking-k8s-io).

**What this PR does / why we need it**:
- Fixes for newer k8s versions.

**Special notes for your reviewer**:
Happy to contribute my part :)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR breaks earlier versions