### PR TITLE
Smooth Kickstart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
               value: {{ .Values.app.memory }}
             - name: FUSIONAUTH_APP_RUNTIME_MODE
               value: {{ .Values.app.runtimeMode }}
+            {{- if .Values.kickstart.enabled }}
+            - name: FUSIONAUTH_APP_KICKSTART_FILE
+              value: "/kickstart/kickstart.json"
+            {{- end }}
             {{- if .Values.environment }}
             {{- toYaml .Values.environment |nindent 12 }}
             {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -109,7 +109,8 @@ environment:
   # - name: FUSIONAUTH_API_KEY
   #   value: test
   # Its important to add /kickstart/<file> as prefix to your kickstart file else it won't work! All other files will be mounted below /kickstart/
-  # - name: FUSIONAUTH_KICKSTART
+  # => Use this environment variable to override the default location '/kickstart/kickstart.json' which is autom. set when kickstart.enabled is set
+  # - name: FUSIONAUTH_APP_KICKSTART_FILE
   #   value: /kickstart/kickstart.json
 
 kickstart:
@@ -121,7 +122,7 @@ kickstart:
     #      "variables": {
     #        "defaultTenantId": "d7d09513-a3f5-401c-9685-34ab6c552453",
     #        "adminEmail": "admin@fusionauth.io",
-    #        "adminPassword": "password",
+    #        "adminPassword": "password"
     #      },
     #      "apiKeys": [
     #        {


### PR DESCRIPTION
Auto set kickstart env if kickstart enabled.


**What this PR does / why we need it**:
Quality of life:
- I tried to set up the kickstart and provided a json based on your example in `values.yaml` (detecting a trailing comma there which I fixed) and realized that I need to manually also set the `env` variable defining the path to the kickstart file. There I added the default path as `env` var when `kickstart.enabled` is set for smoother kickstarting ;)

Fixes:
- Replace deprecated kickstart env in `values.yaml`
- Remove trailing comma in `kickstart.data` field in `values.yaml` rendering it a valid json definition
 
**Special notes for your reviewer**:
This is not required and not fixing a bug, but rather a quality of life change and makes the handling of the kickstarting smoother.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR breaks earlier versions