### PR TITLE
Update Resource specification in HPA to conform to v2beta2 update

### DIFF
--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -20,12 +20,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+        target:
+          type: Utilization        
+          averageUtilization: {{ .Values.autoscaling.targetCPU }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemory  }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: 

The current version of this chart doesn't work when autoscaling is enabled. `apiVersion: autoscaling/v2beta2` of the HorizontalPodAutoscaler object appears to have changed the syntax for specifying target resource utilization.  See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/

**Special notes for your reviewer**:  

No changes to value schema required.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR breaks earlier versions