### PR TITLE
Change deployment replicas to be conditional on autoscaling

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "fusionauth.name" . }}


### PR DESCRIPTION
**What this PR does / why we need it**: 

Right now the deployment replicas value from replicasCount overrides the value from the HorizontalPodAutoscaler.  This causes an issue on deployment where the number of pods can be unintentionally decreased to replicasCount instead of the value managed by HorizontalPodAutoscaler.  

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR breaks earlier versions