### PR TITLE
feat: add serviceMonitor configuration option

### DIFF
--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fusionauth.fullname" $ }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "fusionauth.name" . }}
+    helm.sh/chart: {{ include "fusionauth.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "fusionauth.name" . }}
+      helm.sh/chart: {{ include "fusionauth.chart" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+  endpoints:
+    - port: http
+      {{- with .Values.serviceMonitor.path }}
+      path: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.basicAuth }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -296,3 +296,25 @@ serviceAccount:
   create: false
   # serviceAccount.name -- Service account name to use. If not set the "default" service account will be used
   name: ""
+
+# serviceMonitor -- Configures a Prometheus operator ServiceMonitor custom resource
+# Ref: https://fusionauth.io/docs/v1/tech/tutorials/prometheus
+serviceMonitor:
+  # serviceMonitor.enabled -- Enables creation of a ServiceMonitor
+  enabled: false
+  # serviceMonitor.basicAuth -- Configures basic auth for prometheus, this is required for the serviceMonitor to work with FusionAuth because metrics sit behind an authenticated endpoint
+  basicAuth: {}
+  #  password:
+  #    name: myBasicAuthSecret
+  #    key: password
+  #  username:
+  #    name: myBasicAuthSecret
+  #    key: user
+  # serviceMonitor.path -- Configures path to metrics, defaults to FusionAuth's prometheus metrics API endpoint
+  path: api/prometheus/metrics
+  namespaceSelector: {}
+  annotations: {}
+  labels: {}
+  interval: null
+  scrapeTimeout: null
+  relabelings: []


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a ServiceMonitor custom resource to the helm chart. FusionAuth supports Prometheus metrics as I've discovered recently https://fusionauth.io/docs/v1/tech/tutorials/prometheus, but the chart does not supply a way of adding a ServiceMonitor to enable monitoring via the Prometheus operator. ServiceMonitors are standard in just about every helm chart that I've used. I went to implement the metrics scraping in my environment that we're using FusionAuth, and found that this was missing, so I just went ahead and added it real quick.

**Special notes for your reviewer**:

n/a

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR breaks earlier versions