### PR TITLE
autoscaling/v2 support

### DIFF
--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fusionauth.fullname" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes 1.26 depricates the autoscaling/v2beta2 api. This change allows the chart to support autoscaling/v2.
