### PR TITLE
add safe dir, remove deprecated cr flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global --add safe.directory /__w/charts/charts
 
       - name: Release
         env:
@@ -31,7 +32,6 @@ jobs:
           CR_OWNER: fusionauth
           CR_GIT_REPO: charts
           CR_PACKAGE_PATH: .deploy
-          CR_CHARTS_REPO: https://fusionauth.github.io/charts
           CR_INDEX_PATH: index.yaml
           CR_PAGES_BRANCH: main
           CR_RELEASE_NAME_TEMPLATE: "{{ .Version }}"


### PR DESCRIPTION
<!--  Thank you for contributing to the fusionauth/charts repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: 
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:

* add git safe dir. Newer versions of Git complain about file ownership discrepancies, so the workflow is failing with `detected dubious ownership in repository`
* Remove deprecated param for `cr`. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR breaks earlier versions