### PR TITLE
replace deprecated output with env var to fix chart version test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           cr upload
           cr index --push
           ARCHIVE=$(ls ${CR_PACKAGE_PATH})
-          echo "::set-output name=version::${ARCHIVE%.*}"
+          echo "RELEASED_VERSION=${ARCHIVE%.*}" >> $GITHUB_ENV
 
   install:
     runs-on: ubuntu-22.04
@@ -69,9 +69,9 @@ jobs:
           RELEASED_VERSION: ${{ needs.release.outputs.version }}
         run: |
           INSTALLED_VERSION=$(helm list -m1 -f 'fusionauth*' -o json | jq -r '.[0].chart' )
-          if [[ "${RELEASED_VERSION}" != "${INSTALLED_VERSION}" ]]; then
+          if [[ "${{ env.RELEASED_VERSION }}" != "${INSTALLED_VERSION}" ]]; then
             echo "Incorrect Version Installed ..."
-            echo "Released Version: $RELEASED_VERSION"
+            echo "Released Version: ${{ env.RELEASED_VERSION }}"
             echo "Installed Version: $INSTALLED_VERSION"
             exit 1
           else


### PR DESCRIPTION
<!--  Thank you for contributing to the fusionauth/charts repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: 
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Actions has deprecated `set-output`. This replaces it with env vars to fix the chart version test.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR breaks earlier versions