### PR TITLE
fix: dynamic PodDisruptionBudget apiversion

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -50,6 +50,18 @@ extensions/v1beta1
 {{- end -}}
 
 {{/*
+Set apiVersion for PodDisruptionBudget
+*/}}
+{{- define "fusionauth.PodDisruptionBudget" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+policy/v1
+{{- else -}}
+policy/v1beta1
+{{- end -}}
+{{- end -}}
+
+
+{{/*
 Configure TLS if enabled
 */}}
 {{- define "fusionauth.databaseTLS" -}}

--- a/chart/templates/poddisruptionbudget.yaml
+++ b/chart/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "fusionauth.PodDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fusionauth.fullname" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:

In Kubernetes 1.25, the `policy/v1beta1` API has been deprecated, this PR allows the use of `policy/v1` if available on the cluster
