### PR TITLE
feat: add pod and container securityContext support

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -437,6 +437,12 @@ You should now be able to connect to the FusionAuth application at http://localh
             <td>Define labels for fusionauth Deployment.</td>
         </tr>
         <tr>
+            <td><code>podSecurityContext</code></td>
+            <td>object</td>
+            <td><code>{}</code></td>
+            <td>Security context for the pod. Ref: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">Kubernetes docs</a>.</td>
+        </tr>
+        <tr>
             <td><code>readinessProbe</code></td>
             <td>object</td>
             <td>
@@ -484,6 +490,12 @@ You should now be able to connect to the FusionAuth application at http://localh
             <td>string</td>
             <td><code>"http"</code></td>
             <td>Protocol to use when connecting to elasticsearch. Ignored when <code>search.engine</code> is NOT <code>elasticsearch</code>.</td>
+        </tr>
+        <tr>
+            <td><code>securityContext</code></td>
+            <td>object</td>
+            <td><code>{}</code></td>
+            <td>Security context for the fusionauth container. Ref: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">Kubernetes docs</a>.</td>
         </tr>
         <tr>
             <td><code>service.annotations</code></td>

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -133,6 +133,10 @@ spec:
             {{- end }}
           resources:
               {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 
           {{- if or .Values.kickstart.enabled .Values.extraVolumeMounts }}
           volumeMounts:
@@ -149,6 +153,10 @@ spec:
         {{- if .Values.extraContainers }}
         {{- toYaml .Values.extraContainers | nindent 8 }}
         {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.dnsConfig }}
       dnsConfig:
       {{- toYaml .Values.dnsConfig |nindent 8 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -207,6 +207,9 @@
         "nodeSelector": {
             "type": "object"
         },
+        "podSecurityContext": {
+            "type": "object"
+        },
         "podAnnotations": {
             "type": "object"
         },
@@ -244,6 +247,9 @@
             "type": "integer"
         },
         "resources": {
+            "type": "object"
+        },
+        "securityContext": {
             "type": "object"
         },
         "search": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -229,6 +229,19 @@ autoscaling:
   targetCPU: 50
   # targetMemory: 50
 
+# podSecurityContext -- Security context for the pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+  # runAsNonRoot: true
+  # seccompProfile:
+  #   type: RuntimeDefault
+
+# securityContext -- Security context for the fusionauth container. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext: {}
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #     - ALL
+
 # nodeSelector -- Define nodeSelector for kubernetes to use when scheduling fusionauth pods.
 nodeSelector: {}
 


### PR DESCRIPTION
## Summary
- Add `podSecurityContext` and `securityContext` values for pod-level and container-level security context
- Enables compliance with Kubernetes restricted Pod Security Standard
- Backwards compatible: no securityContext rendered when values are empty

## Test plan
- [x] `helm lint` passes
- [x] `helm template` renders securityContext blocks when values are set
- [x] No securityContext block rendered without values (backwards compatible)